### PR TITLE
Bump protobufjs from 7.4.0 to 7.5.5 in /ios

### DIFF
--- a/ios/package-lock.json
+++ b/ios/package-lock.json
@@ -7026,9 +7026,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
-      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {


### PR DESCRIPTION
## Summary

- Bumps `protobufjs` from 7.4.0 to 7.5.5 in the `/ios` directory to fix an arbitrary code execution vulnerability ([GHSA-xq3m-2v4x-88gg](https://github.com/advisories/GHSA-xq3m-2v4x-88gg))
- The `/android` directory was already patched to 7.5.5 via Dependabot PR #46 -- this brings iOS in line
- Only `ios/package-lock.json` is changed (transitive dependency version bump, no code changes)

## JIRA

[AAP-18854](https://browserstack.atlassian.net/browse/AAP-18854)

## Test plan

- [x] Verified `protobufjs` resolves to 7.5.5 in `ios/package-lock.json`
- [x] Confirmed no breaking changes -- protobufjs 7.5.5 is a patch release compatible with ^7.2.5
- [x] Verified android directory already has 7.5.5 (consistency check)
- [ ] CI passes on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AAP-18854]: https://browserstack.atlassian.net/browse/AAP-18854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ